### PR TITLE
testing adding cookies and reading in API

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -7,7 +7,7 @@ export default function Login() {
 
   if (session) {
     console.log(session.user);
-    setCookie("user", JSON.stringify(session.user?.email), {
+    setCookie("user", session.user?.email, {
       path: "/",
       sameSite: true,
     });
@@ -19,11 +19,12 @@ export default function Login() {
       </>
     );
   }
-  setCookie("user", "jordan.raleigh"),
-    {
-      path: "/",
-      sameSite: true,
-    };
+  //Cookie Testing Purposes
+  //setCookie("user", "jordan.raleigh"),
+  //   {
+  //     path: "/",
+  //     sameSite: true,
+  //   };
   return (
     <>
       Not signed in <br />


### PR DESCRIPTION
Removed json.stringify for vercel test

## Description

This code adds the year into the achievement and tries to add cookies for the username once loggedin which should then grab it in the API to display the achievements. Need to push to prod to test in vercel due to Google callback URI issue.

## Type of Changes

<!-- Remove lines that aren't appropriate for your merge request -->

| Type                       |
| -------------------------- |
| :sparkles: New feature     |

## Before / Current Behavior
![](https://cdn.zappy.app/9b4c01c3525c49c211420f2665937120.png)

## After / New Behavior
![](https://cdn.zappy.app/cb11e3cf5cdd155d865382a80f68832f.png)


