### PR TITLE
Built workaround to enable google oauth testing while in localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 80",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -8,7 +8,7 @@ const options = {
       clientSecret: process.env.GOOGLE_SECRET,
     }),
   ],
-  debug: false,
+  debug: true,
 };
 
 // eslint-disable-next-line

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -8,7 +8,7 @@ const options = {
       clientSecret: process.env.GOOGLE_SECRET,
     }),
   ],
-  debug: true,
+  debug: false,
 };
 
 // eslint-disable-next-line


### PR DESCRIPTION
## Description
Added functionality to be able to test locally with Google Oauth 2.0. Before I needed to push to the main vercel deployment and test in production which is not ideal. Now I am able to redirect back to my localhost which enables full testing and access to the app while in localhost. 

## Type of Changes

<!-- Remove lines that aren't appropriate for your merge request -->

| Type                       |
| -------------------------- |
| :sparkles: New feature     |

## Before / Current Behavior
![](https://cdn.zappy.app/fb4467d64545faf9574d06c8d5560ed1.png)

## After / New Behavior
![](https://cdn.zappy.app/af5e5aeed9a5158cd1a830dd06c2664d.png)

## Testing Steps / QA Criteria
1. Edit /etc/hosts to the below
![](https://cdn.zappy.app/b4fafe372400c9bba2608ad4e245ff76.png)
3. In ```.env``` add ```NEXTAUTH_URL=http://zapierlocal.com/api/auth``` and ```PORT=80``` to change callback URL's to match the new alias
4. Run server and login
